### PR TITLE
2 labctl 001 define vmconfig struct in internalvm

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/blackmagicbox/labctl/internal/tui"
@@ -23,7 +22,7 @@ var newCmd = &cobra.Command{
 			_, _ = fmt.Fprintf(os.Stderr, "error %v\n", err)
 		}
 		finalModel := result.(tui.Model)
-		fmt.Printf("\nVM: \n%v\n", strings.Join(finalModel.Value(), "\n"))
+		fmt.Printf("\n%v\n", finalModel.Value().String())
 
 	},
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -255,15 +255,15 @@ func (m Model) View() tea.View {
 }
 
 func (m Model) Value() *vm.Config {
-	vmConfig := vm.NewVMConfig(
-		m.VMName.Value(),
-		m.Hostname.Value(),
-		m.Username.Value(),
-		m.Disk.Value(),
-		m.Memory.Value(),
-		m.CPU.Value(),
-		m.Distro.Value(),
-		m.Image.Value(),
-	)
-	return vmConfig
+	vmConfig := vm.Config{
+		Distro:   m.VMName.Value(),
+		Image:    m.Hostname.Value(),
+		VMName:   m.Username.Value(),
+		Username: m.Disk.Value(),
+		Hostname: m.Memory.Value(),
+		Disk:     m.CPU.Value(),
+		Memory:   m.Distro.Value(),
+		CPU:      m.Image.Value(),
+	}
+	return &vmConfig
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -23,7 +23,6 @@ const (
 	stepMemory
 	stepCPU
 	stepConfirm
-	stepFinish
 )
 
 type Model struct {
@@ -183,17 +182,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if m.Confirmation.Value() == "Yes" {
 						// Todo: Start the new VM
 					}
-					m.step = stepFinish
-				}
-			case stepFinish:
-				k := msg.String()
-				if m.step > stepConfirm && k == "enter" {
 					return m, tea.Quit
 				}
 			default:
-				panic("unhandled model update")
 			}
-
 		}
 	}
 	var cmd tea.Cmd
@@ -256,14 +248,14 @@ func (m Model) View() tea.View {
 
 func (m Model) Value() *vm.Config {
 	vmConfig := vm.Config{
-		Distro:   m.VMName.Value(),
-		Image:    m.Hostname.Value(),
-		VMName:   m.Username.Value(),
-		Username: m.Disk.Value(),
-		Hostname: m.Memory.Value(),
-		Disk:     m.CPU.Value(),
-		Memory:   m.Distro.Value(),
-		CPU:      m.Image.Value(),
+		Distro:   m.Distro.Value(),
+		Image:    m.Image.Value(),
+		VMName:   m.VMName.Value(),
+		Username: m.Username.Value(),
+		Hostname: m.Hostname.Value(),
+		Disk:     m.Disk.Value(),
+		Memory:   m.Memory.Value(),
+		CPU:      m.CPU.Value(),
 	}
 	return &vmConfig
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
+	"github.com/blackmagicbox/labctl/internal/vm"
 )
 
 type step int
@@ -21,18 +22,21 @@ const (
 	stepDisk
 	stepMemory
 	stepCPU
+	stepConfirm
+	stepFinish
 )
 
 type Model struct {
-	step     step
-	Distro   selectModel
-	Image    selectModel
-	VMName   textinput.Model
-	Hostname textinput.Model
-	Username textinput.Model
-	Disk     textinput.Model
-	Memory   textinput.Model
-	CPU      textinput.Model
+	step         step
+	Distro       selectModel
+	Image        selectModel
+	VMName       textinput.Model
+	Hostname     textinput.Model
+	Username     textinput.Model
+	Disk         textinput.Model
+	Memory       textinput.Model
+	CPU          textinput.Model
+	Confirmation selectModel
 }
 
 var Images = map[string][]string{
@@ -73,14 +77,15 @@ func New() Model {
 	c.SetWidth(20)
 
 	return Model{
-		step:     stepDistro,
-		Distro:   newSelect("distro", []string{"Debian/Ubuntu", "Rhel/Fedora", "Arch/Manjaro"}),
-		VMName:   n,
-		Hostname: h,
-		Username: u,
-		Disk:     d,
-		Memory:   m,
-		CPU:      c,
+		step:         stepDistro,
+		Distro:       newSelect("distro", []string{"Debian/Ubuntu", "Rhel/Fedora", "Arch/Manjaro"}),
+		VMName:       n,
+		Hostname:     h,
+		Username:     u,
+		Disk:         d,
+		Memory:       m,
+		CPU:          c,
+		Confirmation: newSelect("Start the new VM after the wizard", []string{"Yes", "No"}),
 	}
 }
 
@@ -92,13 +97,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		switch msg.String() {
-		case "q":
-			if m.step == stepDistro || m.step == stepImage {
-				return m, tea.Quit
-			}
 		case "ctrl+c":
 			return m, tea.Quit
 		default:
+			k := msg.String()
+			if k == `q` && (m.step == stepDistro || m.step == stepImage) {
+				return m, tea.Quit
+			}
 			switch m.step {
 			case stepDistro:
 				m.Distro, _ = m.Distro.Update(msg)
@@ -170,12 +175,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if m.CPU.Value() == "" {
 						m.CPU.SetValue(m.CPU.Placeholder)
 					}
-					m.step++
+					m.step = stepConfirm
+				}
+			case stepConfirm:
+				m.Confirmation, _ = m.Confirmation.Update(msg)
+				if m.Confirmation.Chosen() {
+					if m.Confirmation.Value() == "Yes" {
+						// Todo: Start the new VM
+					}
+					m.step = stepFinish
+				}
+			case stepFinish:
+				k := msg.String()
+				if m.step > stepConfirm && k == "enter" {
+					return m, tea.Quit
 				}
 			default:
+				panic("unhandled model update")
 			}
-		}
 
+		}
 	}
 	var cmd tea.Cmd
 	return m, cmd
@@ -207,6 +226,9 @@ func (m Model) View() tea.View {
 	if m.CPU.Value() != "" && !m.CPU.Focused() {
 		out = fmt.Sprintf("%s✔ CPU: %s\n", out, m.CPU.View())
 	}
+	if m.Confirmation.Chosen() {
+		out = fmt.Sprintf("%s✔ Start the vm: (%s)\n", out, m.Confirmation.Value())
+	}
 
 	switch m.step {
 	case stepDistro:
@@ -225,14 +247,15 @@ func (m Model) View() tea.View {
 		return tea.NewView(fmt.Sprintf("%s? memory: %s", out, m.Memory.View()))
 	case stepCPU:
 		return tea.NewView(fmt.Sprintf("%s? CPU: %s", out, m.CPU.View()))
+	case stepConfirm:
+		return tea.NewView(fmt.Sprintf("%s%s", out, m.Confirmation.View().Content))
 	default:
 		return tea.NewView(out)
 	}
 }
 
-func (m Model) Value() []string {
-	// Return a String with all the settings
-	return []string{
+func (m Model) Value() *vm.Config {
+	vmConfig := vm.NewVMConfig(
 		m.VMName.Value(),
 		m.Hostname.Value(),
 		m.Username.Value(),
@@ -241,5 +264,6 @@ func (m Model) Value() []string {
 		m.CPU.Value(),
 		m.Distro.Value(),
 		m.Image.Value(),
-	}
+	)
+	return vmConfig
 }

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -1,0 +1,41 @@
+package vm
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type Config struct {
+	Distro   string
+	Image    string
+	VMName   string
+	Username string
+	Hostname string
+	Disk     string
+	Memory   string
+	CPU      string
+}
+
+func NewVMConfig(distro, image, vmName, username, hostname, disk, memory, cpu string) *Config {
+	return &Config{
+		Distro:   distro,
+		Image:    image,
+		VMName:   vmName,
+		Username: username,
+		Hostname: hostname,
+		Disk:     disk,
+		Memory:   memory,
+		CPU:      cpu,
+	}
+}
+
+func (c *Config) String() string {
+	out := "VM Config: \n"
+	val := reflect.ValueOf(c).Elem()
+	typeOfStruct := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		out = fmt.Sprintf("%s  %s: %v\n", out, typeOfStruct.Field(i).Name, val.Field(i).String())
+	}
+	return out
+}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -1,9 +1,6 @@
 package vm
 
-import (
-	"fmt"
-	"reflect"
-)
+import "fmt"
 
 type Config struct {
 	Distro   string
@@ -16,26 +13,24 @@ type Config struct {
 	CPU      string
 }
 
-func NewVMConfig(distro, image, vmName, username, hostname, disk, memory, cpu string) *Config {
-	return &Config{
-		Distro:   distro,
-		Image:    image,
-		VMName:   vmName,
-		Username: username,
-		Hostname: hostname,
-		Disk:     disk,
-		Memory:   memory,
-		CPU:      cpu,
-	}
-}
-
-func (c *Config) String() string {
-	out := "VM Config: \n"
-	val := reflect.ValueOf(c).Elem()
-	typeOfStruct := val.Type()
-
-	for i := 0; i < val.NumField(); i++ {
-		out = fmt.Sprintf("%s  %s: %v\n", out, typeOfStruct.Field(i).Name, val.Field(i).String())
-	}
-	return out
+func (c Config) String() string {
+	return fmt.Sprintf(
+		"VMConfig:\n"+
+			"  Distro: %s\n"+
+			"  Image: %s\n"+
+			"  VMName: %s\n"+
+			"  Username: %s\n"+
+			"  Hostname: %s\n"+
+			"  Disk: %s\n"+
+			"  Memory: %s\n"+
+			"  CPU: %s\n",
+		c.Distro,
+		c.Image,
+		c.VMName,
+		c.Username,
+		c.Hostname,
+		c.Disk,
+		c.Memory,
+		c.CPU,
+	)
 }


### PR DESCRIPTION
This pull request introduces a new confirmation step to the TUI VM creation wizard and refactors how VM configuration data is handled and displayed. The changes improve the user experience by providing a clear summary and confirmation before finalizing VM creation, and by encapsulating VM configuration in a dedicated struct.

Wizard flow and user experience improvements:

* Added a new confirmation step (`stepConfirm`) to the TUI wizard, prompting the user to confirm whether to start the VM after completing the setup, and displaying the confirmation choice in the summary view. [[1]](diffhunk://#diff-a20a3653ce3e78dcedae8526a9dc61db856e8bce3825cbc37cf2f15482f63142R25) [[2]](diffhunk://#diff-a20a3653ce3e78dcedae8526a9dc61db856e8bce3825cbc37cf2f15482f63142R38) [[3]](diffhunk://#diff-a20a3653ce3e78dcedae8526a9dc61db856e8bce3825cbc37cf2f15482f63142R87) [[4]](diffhunk://#diff-a20a3653ce3e78dcedae8526a9dc61db856e8bce3825cbc37cf2f15482f63142L173-L178) [[5]](diffhunk://#diff-a20a3653ce3e78dcedae8526a9dc61db856e8bce3825cbc37cf2f15482f63142R221-R223) [[6]](diffhunk://#diff-a20a3653ce3e78dcedae8526a9dc61db856e8bce3825cbc37cf2f15482f63142R242-R260)
* Improved quit logic in the TUI so that 'q' only exits at appropriate steps, making the flow more intuitive.

VM configuration handling:

* Replaced the previous slice-based `Value()` method with a new method returning a strongly typed `vm.Config` struct, improving type safety and maintainability. [[1]](diffhunk://#diff-a20a3653ce3e78dcedae8526a9dc61db856e8bce3825cbc37cf2f15482f63142R242-R260) [[2]](diffhunk://#diff-d1124e8991e10b74a2af9007919a02ed1c63287e2d8e82134fe0388f89934ebcR1-R36)
* Updated the output in `cmd/new.go` to print the VM configuration using the new `String()` method of `vm.Config` for clearer, formatted output.

Code organization:

* Introduced a new `internal/vm/vm.go` file containing the `Config` struct and its `String()` method for centralized VM configuration management.
* Cleaned up unused imports in `cmd/new.go` to keep dependencies minimal.